### PR TITLE
Correct hardcode of Container Name when stopping the container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ function _get_phy_from_dev() {
 function _cleanup() {
   echo -e "\n* cleaning up..."
   echo "* stopping container"
-  docker stop openwrt_1 >/dev/null
+  docker stop $CONTAINER >/dev/null
   echo "* cleaning up netns symlink"
   sudo rm -rf /var/run/netns/$CONTAINER
   echo "* removing DHCP lease"


### PR DESCRIPTION
Hi oofnikj,

Found a bug. The command to stop Container is hardcoded. Change it back to $CONTAINER.