### PR TITLE
Macvlan for lan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ RUN opkg remove dnsmasq && \
       ip-full \
       kmod-mac80211 \
       iperf3 \
-      dnsmasq-full
+      dnsmasq-full \
+      iptables-mod-checksum
 RUN opkg list-upgradable | awk '{print $1}' | xargs opkg upgrade
+RUN echo "iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill" >> /etc/firewall.user
 
 CMD [ "/sbin/init" ]

--- a/openwrt.conf.example
+++ b/openwrt.conf.example
@@ -20,6 +20,8 @@ UPSTREAM_DNS_SERVER=8.8.8.8
 
 # Static IP address configuration for OpenWRT LAN
 LAN_NAME=openwrt-lan
+# host interface which will provide the LAN link for OpenWRT
+LAN_PARENT=eth1
 LAN_DOMAIN=home
 LAN_SUBNET=192.168.16.0/24
 LAN6_SUBNET=fd99:1234::/48

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,8 @@ function _gen_config() {
 
 function _init_network() {
   echo "* setting up docker network"
-  docker network create --driver bridge \
+  docker network create --driver macvlan \
+    -o parent=$LAN_PARENT \
     --subnet $LAN_SUBNET \
     $LAN_NAME || exit 1
 


### PR DESCRIPTION
Hi @v01ded, I finally figured out the issue I had with macvlan networking for LAN.

The issue I was having is related to an old kernel bug (feature?) that disables checksumming for UDP packets on virtual interfaces. The assumption is that there is no value in computing a UDP checksum for a virtual interface since there is no physical transmission occurring, thus no chance of packet corruption. However, this does not play nice with DHCP/BOOTP clients.

You can see the bad UDP checksum error in tcpdump:
```
$ tcpdump -Xvveni eth0
...
08:31:25.305099 02:42:c0:a8:12:02 > 5a:d7:6a:e4:4c:b5, ethertype IPv4 (0x0800), length 342: (tos 0xc0, ttl 64, id 49467, offset 0, flags [none], proto UDP (17), length 328)
    192.168.18.2.67 > 192.168.18.150.68: [bad udp cksum 0xa72e -> 0xdee9!] BOOTP/DHCP, Reply, length 300, xid 0xe33873cf, secs 12, Flags [none] (0x0000)
```

This issue was mostly resolved upstream for things like QEMU / KVM where virtual interfaces are extensively used.

I managed to fix this in @d26a0a6 by adding an iptables rule to force a checksum on outgoing DHCP packets, overriding the default kernel behavior on virtual interfaces.

Some references: 
https://lorinstechblog.wordpress.com/2013/06/05/the-infamous-checksum-bug/
https://git.devuan.org/gregolsen/lxc-devuan/issues/1
https://bugs.launchpad.net/ubuntu/+source/isc-dhcp/+bug/930962
https://tools.ietf.org/html/rfc768
