### PR TITLE
switch back to building from scratch for 19.07.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG OPENWRT_TAG
-FROM openwrtorg/rootfs:${OPENWRT_TAG}
+FROM scratch
+ARG OPENWRT_SOURCE_VER
+ADD openwrt-${OPENWRT_SOURCE_VER}-x86-64-generic-rootfs.tar.gz /
 ARG ROOT_PW
 RUN echo -e "${ROOT_PW}\n${ROOT_PW}" | passwd
 RUN mkdir -p /var/lock

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ include openwrt.conf
 export
 
 build:
+	wget -q https://downloads.openwrt.org/releases/${OPENWRT_SOURCE_VER}/targets/x86/64/openwrt-${OPENWRT_SOURCE_VER}-x86-64-generic-rootfs.tar.gz
 	docker build \
 		--build-arg ROOT_PW \
-		--build-arg OPENWRT_TAG \
+		--build-arg OPENWRT_SOURCE_VER \
 		-t ${BUILD_TAG} .
+	rm openwrt-${OPENWRT_SOURCE_VER}-x86-64-generic-rootfs.tar.gz
 
 build-rpi:
 	./build-rpi.sh ${RPI_SOURCE_IMG}

--- a/openwrt.conf.example
+++ b/openwrt.conf.example
@@ -3,8 +3,8 @@
 ## general
 # source image for Raspberry Pi build target
 SOURCE_IMG=openwrt-19.07.2-brcm2708-bcm2708-rpi-ext4-factory.img
-# source tag for build (x86) target
-OPENWRT_TAG=x86-64-19.07.2
+# source for build (x86) target
+OPENWRT_SOURCE_VER=19.07.3
 # final tag for built Docker image
 BUILD_TAG=openwrt
 # container name 


### PR DESCRIPTION
There's no Docker rootfs image available yet for 19.07.3, so we build one from the rootfs tar