### PR TITLE
Docker bridge to act as main interface for lan,static host ip, assert revert namespace of wlan0

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -48,6 +48,8 @@ function _cleanup() {
 	echo "* Rolling back ip address for main if"
 	sudo service dhcpcd start
 	sudo dhclient -r
+	test $WIFI_ENABLED = 'false' || echo "* returning $WIFI_PHY to host"
+	test $WIFI_ENABLED = 'false' || sudo iw phy "$WIFI_PHY" set netns 1
 	echo -ne "* finished"
 }
 


### PR DESCRIPTION
This addresses the issues I encountered in https://github.com/oofnikj/docker-openwrt/issues/12
and also wlan0 would not return to host stack occasionally, so I've added it explicitly.