### PR TITLE
move resolv.conf fix to rc.local to avoid race condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,9 @@ RUN opkg remove dnsmasq && \
       dnsmasq-full \
       iptables-mod-checksum
 RUN opkg list-upgradable | awk '{print $1}' | xargs opkg upgrade || true
+
 RUN echo "iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill" >> /etc/firewall.user
+RUN sed -i '/^exit 0/i cat \/tmp\/resolv.conf > \/etc\/resolv.conf' /etc/rc.local
 
 ARG ts
 ARG version

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -7,6 +7,9 @@ RUN opkg update && \
       iperf3 \
       ip-full
 RUN  opkg list-upgradable | awk '{print $1}' | xargs opkg upgrade || true
+
+RUN sed -i '/^exit 0/i cat \/tmp\/resolv.conf > \/etc\/resolv.conf' /etc/rc.local
+
 ARG ts
 ARG version
 LABEL org.opencontainers.image.created=$ts

--- a/run.sh
+++ b/run.sh
@@ -197,10 +197,6 @@ _prepare_network() {
 			uci commit"
 	fi
 
-	echo "* restore resolv.conf"
-	docker exec -it $CONTAINER sh -c '
-		cat /tmp/resolv.conf > /etc/resolv.conf'
-
 	echo "* getting address via DHCP"
 	sudo dhcpcd -q $LAN_IFACE
 }


### PR DESCRIPTION
Docker bind mounts `/etc/resolv.conf` from the host, overwriting the symlink from `/tmp/resolv.conf`, which breaks DNS functionality inside the container (but not for LAN clients). We restore it by overwriting the contents of the bind-mounted file from `/tmp`.

Previously this was done by executing a process in `run.sh`, but this resulted in a race condition where sometimes `/tmp/resolv.conf` was ready, sometimes, it wasn't. By moving to `/etc/rc.local`, it's guaranteed to run after system init is done.