### PR TITLE
switch to squashfs for bcm2708 target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,20 +20,12 @@ variables:
   only:
     - master
 
-.build-loopmount:
+.build-squashfs:
   extends: .build
-  variables:
-    LOOP_ARGS: '=/tmp/dev/loop0'
   before_script:
     - docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN
     - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    - apk add util-linux
-    - |
-      mkdir -p /tmp/dev
-      mount -t devtmpfs none /tmp/dev
-      for i in $(seq 0 9); do
-        mknod -m 0660 "/tmp/dev/loop$i" b 7 "$i"
-      done
+    - apk add fakeroot squashfs-tools
 
 build-release-x86-64:
   extends: .build
@@ -51,7 +43,7 @@ build-release-armvirt-32:
     ARCH: armvirt-32
 
 build-release-bcm2708:
-  extends: .build-loopmount
+  extends: .build-squashfs
   variables:
     ARCH: bcm2708
 
@@ -74,7 +66,7 @@ build-snapshot-armvirt-32:
     RELEASE: snapshot
 
 build-snapshot-bcm2708:
-  extends: .build-loopmount
+  extends: .build-squashfs
   variables:
     ARCH: bcm2708
     RELEASE: snapshot

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ download_rootfs() {
 		snapshot)
 		# special snowflake raspberry pi zero
 			if [[ $ARCH = "bcm2708" ]] ; then
-				img_url="https://downloads.openwrt.org/snapshots/targets/bcm27xx/bcm2708/openwrt-bcm27xx-bcm2708-rpi-ext4-factory.img.gz"
+				img_url="https://downloads.openwrt.org/snapshots/targets/bcm27xx/bcm2708/openwrt-bcm27xx-bcm2708-rpi-squashfs-factory.img.gz"
 				version="https://downloads.openwrt.org/snapshots/targets/bcm27xx/bcm2708/version.buildinfo"
 				gen_rootfs_from_img
 				return

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ download_rootfs() {
 		;;
 		*)
 			if [[ $ARCH = "bcm2708" ]] ; then
-				img_url="https://downloads.openwrt.org/releases/${OPENWRT_SOURCE_VER}/targets/brcm2708/bcm2708/openwrt-${OPENWRT_SOURCE_VER}-brcm2708-bcm2708-rpi-ext4-factory.img.gz"
+				img_url="https://downloads.openwrt.org/releases/${OPENWRT_SOURCE_VER}/targets/brcm2708/bcm2708/openwrt-${OPENWRT_SOURCE_VER}-brcm2708-bcm2708-rpi-squashfs-factory.img.gz"
 				version="https://downloads.openwrt.org/releases/${OPENWRT_SOURCE_VER}/targets/brcm2708/bcm2708/version.buildinfo"
 				gen_rootfs_from_img
 				return
@@ -50,22 +50,13 @@ download_rootfs() {
 	wget "${version}" -O version.buildinfo
 }
 
-check_uid() {
-	if [[ $(id -u) -ne 0 ]]; then
-		echo "this script requires root privileges"
-		exit 1
-	fi
-}
-
 gen_rootfs_from_img() {
-	check_uid
 	local offset
 	wget "${img_url}" -O- | gzip -d > image.img
 	wget "${version}" -O version.buildinfo
-	mkdir -p "${tmpdir}"
 	offset=$(sfdisk -d image.img | grep "image.img2" | sed -E 's/.*start=\s+([0-9]+).*/\1/g')
-	mount -o loop"${LOOP_ARGS}",offset=$((512 * $offset)) -t ext4 image.img ${tmpdir}
-	tar czf rootfs.tar.gz -C ${tmpdir} .
+	fakeroot unsquashfs -no-progress -quiet -offset $(( 512 * $offset )) -dest ${tmpdir} image.img
+	fakeroot tar czf rootfs.tar.gz -C ${tmpdir} .
 }
 
 docker_build() {
@@ -78,7 +69,6 @@ docker_build() {
 cleanup() {
 	rm -rf rootfs.tar.gz version.buildinfo image.img
 	if [[ -d $tmpdir ]] ; then
-		umount -q $tmpdir || true
 		rm -rf $tmpdir
 	fi
 }

--- a/docs/rpi.md
+++ b/docs/rpi.md
@@ -17,7 +17,7 @@ Set the `IMAGE` and `TAG` variables in openwrt.conf accordingly, replacing `<ver
 
 ---
 ## Build 
-You can build the OpenWrt Docker image yourself on the Pi, or on your x86 PC with `qemu-user` and `binfmt-support` installed. The image will be built according to the parameters `OPENWRT_SOURCE_VER`, `ARCH`, `IMAGE` and `TAG` (see [openwrt.conf](../openwrt.conf.example) for documentation). Note that target `bcm2708` requires root privileges.
+You can build the OpenWrt Docker image yourself on the Pi, or on your x86 PC with `qemu-user` and `binfmt-support` installed. The image will be built according to the parameters `OPENWRT_SOURCE_VER`, `ARCH`, `IMAGE` and `TAG` (see [openwrt.conf](../openwrt.conf.example) for documentation). Packages `fakeroot` and `squashfs-tools` must be installed.
 
 ```shell
 $ make build


### PR DESCRIPTION
Eliminate requirement for root privileges by switching to squashfs from ext4 for bcm2708 target

Signed-off-by: Jordan Sokolic <oofnik@gmail.com>