### PR TITLE
Bump OpenWrt to 19.07.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   CI_IMAGE: $DOCKER_HUB_USER/openwrt
-  RELEASE: "19.07.7"
+  RELEASE: "19.07.8"
 
 .build:
   image: docker:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM scratch
+
 ADD rootfs.tar.gz /
-RUN mkdir -p /var/lock
-RUN opkg remove --force-depends \
+
+RUN mkdir -p /var/lock && \
+    opkg remove --force-depends \
       dnsmasq* \
       wpad* \
       iw* && \
@@ -13,10 +15,10 @@ RUN opkg remove --force-depends \
       kmod-mac80211 \
       dnsmasq-full \
       iptables-mod-checksum
-RUN opkg list-upgradable | awk '{print $1}' | xargs opkg upgrade || true
 
-RUN echo "iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill" >> /etc/firewall.user
-RUN sed -i '/^exit 0/i cat \/tmp\/resolv.conf > \/etc\/resolv.conf' /etc/rc.local
+RUN opkg list-upgradable | awk '{print $1}' | xargs opkg upgrade || true && \
+    echo "iptables -A POSTROUTING -t mangle -p udp --dport 68 -j CHECKSUM --checksum-fill" >> /etc/firewall.user && \
+    sed -i '/^exit 0/i cat \/tmp\/resolv.conf > \/etc\/resolv.conf' /etc/rc.local
 
 ARG ts
 ARG version

--- a/openwrt.conf.example
+++ b/openwrt.conf.example
@@ -2,7 +2,7 @@
 
 ## General
 # OpenWrt version. Set to 'snapshot' to build from latest snapshot
-OPENWRT_SOURCE_VER=19.07.7
+OPENWRT_SOURCE_VER=19.07.8
 # Architecture: one of x86-64, armvirt-32 (Raspberry Pi 2 / 3 / 4),
 # armvirt-64 (Raspberry Pi 3 / 4 running 64-bit OS, ODroid-C2 or similar),
 # or bcm2708 (Raspberry Pi Zero)


### PR DESCRIPTION
* Update OpenWrt to latest 19.07 release
* Merge some of the layers in the Docker image.

Major security fixes with this release:

Security fixes
* Fix FragAttacks (fragmentation and aggregation attacks) vulnerabilities in cfg80211, mac80211, ath10k and ath10k-ct
* We are not sure if some closed source firmware files are still affected by these problems.
* Security Advisory 2021-08-01-1 - XSS via missing input validation of host names displayed (CVE-2021-32019) 19
* Security Advisory 2021-08-01-2 - Stored XSS in hostname UCI variable (CVE-2021-33425) 9
* Security Advisory 2021-08-01-3 - luci-app-ddns: Multiple authenticated RCEs (CVE-2021-28961) 11

Release notes: https://forum.openwrt.org/t/openwrt-19-07-8-service-release/103208